### PR TITLE
Start and end dates can be specified as command line arguments

### DIFF
--- a/get-yahoo-quotes.py
+++ b/get-yahoo-quotes.py
@@ -72,24 +72,27 @@ def get_now_epoch():
     # @see https://www.linuxquestions.org/questions/programming-9/python-datetime-to-epoch-4175520007/#post5244109
     return int(time.time())
 
+	
 def get_time_epoch(iso_time):
     return calendar.timegm(time.strptime(iso_time, '%Y-%m-%d'))
 
-def download_quotes(symbol):
-    start_date = get_time_epoch('2012-01-01')
-    end_date = get_now_epoch()
+	
+def download_quotes(symbol, start_date, end_date):
     cookie, crumb = get_cookie_crumb(symbol)
     get_data(symbol, start_date, end_date, cookie, crumb)
 
 
 if __name__ == '__main__':
     # If we have at least one parameter go ahead and loop overa all the parameters assuming they are symbols
+    start_date = get_time_epoch('1970-01-01')
+    end_date = get_now_epoch()
+
     if len(sys.argv) == 1:
-        print("\nUsage: get-yahoo-quotes.py SYMBOL START_DATE END_DATE\n\n")
+        print("\nUsage: get-yahoo-quotes.py SYMBOL [optional]START_DATE [optional]END_DATE\n\n")
     else:
         for i in range(1, len(sys.argv)):
             symbol = sys.argv[i]
             print("--------------------------------------------------")
             print("Downloading %s to %s.csv" % (symbol, symbol))
-            download_quotes(symbol)
+            download_quotes(symbol, start_date, end_date)
 print("--------------------------------------------------")

--- a/get-yahoo-quotes.py
+++ b/get-yahoo-quotes.py
@@ -2,13 +2,9 @@
 
 """
 get-yahoo-quotes.py:  Script to download Yahoo historical quotes using the new cookie authenticated site.
-
  Usage: get-yahoo-quotes SYMBOL
-
  History
-
  06-03-2017 : Created script
-
 """
 
 __author__ = "Brad Luicas"
@@ -25,6 +21,7 @@ import sys
 import time
 import datetime
 import requests
+import calendar
 
 
 def split_crumb_store(v):
@@ -75,9 +72,11 @@ def get_now_epoch():
     # @see https://www.linuxquestions.org/questions/programming-9/python-datetime-to-epoch-4175520007/#post5244109
     return int(time.time())
 
+def get_time_epoch(iso_time):
+    return calendar.timegm(time.strptime(iso_time, '%Y-%m-%d'))
 
 def download_quotes(symbol):
-    start_date = 0
+    start_date = get_time_epoch('2012-01-01')
     end_date = get_now_epoch()
     cookie, crumb = get_cookie_crumb(symbol)
     get_data(symbol, start_date, end_date, cookie, crumb)
@@ -86,11 +85,11 @@ def download_quotes(symbol):
 if __name__ == '__main__':
     # If we have at least one parameter go ahead and loop overa all the parameters assuming they are symbols
     if len(sys.argv) == 1:
-        print("\nUsage: get-yahoo-quotes.py SYMBOL\n\n")
+        print("\nUsage: get-yahoo-quotes.py SYMBOL START_DATE END_DATE\n\n")
     else:
         for i in range(1, len(sys.argv)):
             symbol = sys.argv[i]
             print("--------------------------------------------------")
             print("Downloading %s to %s.csv" % (symbol, symbol))
             download_quotes(symbol)
-            print("--------------------------------------------------")
+print("--------------------------------------------------")

--- a/get-yahoo-quotes.py
+++ b/get-yahoo-quotes.py
@@ -88,7 +88,7 @@ def main():
     end_date = get_now_epoch()
 
     if len(sys.argv) == 1:
-        print("\nUsage: get-yahoo-quotes.py SYMBOL [optional]START_DATE [optional]END_DATE\n\n")
+        print("\nUsage: get-yahoo-quotes.py SYMBOL [optional yyyy-mm-dd]START_DATE [optional yyyy-mm-dd]END_DATE\n\n")
         return
     
     symbol = sys.argv[1]    

--- a/get-yahoo-quotes.py
+++ b/get-yahoo-quotes.py
@@ -82,17 +82,27 @@ def download_quotes(symbol, start_date, end_date):
     get_data(symbol, start_date, end_date, cookie, crumb)
 
 
-if __name__ == '__main__':
+def main():
     # If we have at least one parameter go ahead and loop overa all the parameters assuming they are symbols
     start_date = get_time_epoch('1970-01-01')
     end_date = get_now_epoch()
 
     if len(sys.argv) == 1:
         print("\nUsage: get-yahoo-quotes.py SYMBOL [optional]START_DATE [optional]END_DATE\n\n")
-    else:
-        for i in range(1, len(sys.argv)):
-            symbol = sys.argv[i]
-            print("--------------------------------------------------")
-            print("Downloading %s to %s.csv" % (symbol, symbol))
-            download_quotes(symbol, start_date, end_date)
+        return
+    
+    symbol = sys.argv[1]    
+    if len(sys.argv) > 2:
+        start_date = get_time_epoch(sys.argv[2])
+    
+    if len(sys.argv) > 3:
+        end_date = get_time_epoch(sys.argv[3])
+    
+    print("Downloading %s to %s.csv" % (symbol, symbol))
+    download_quotes(symbol, start_date, end_date)    
+
+
+if __name__ == '__main__':
+    main()
+
 print("--------------------------------------------------")


### PR DESCRIPTION
Start and end dates can now be specified as command line arguments (iso format yyyy-mm-dd).

But it now loses the ability to specify multiple stock symbols in the command line.
Seeing as this was just iterating over the list of stock symbols and since its going over a HTTP connection to get daily OHLCV data, I figured performance wasn't going to be critical.  As a result, if anyone did want to specify a list of stocks, they could do so as a bash script or python program which simply calls this one for each stock symbol they were interested in.

Any suggestions or thoughts on this? :)